### PR TITLE
[FIX]: cambiar la estructura del DTO para crear una asistencia

### DIFF
--- a/src/main/java/asist/io/dto/asistenciaDTO/AsistenciaCreateDTO.java
+++ b/src/main/java/asist/io/dto/asistenciaDTO/AsistenciaCreateDTO.java
@@ -1,0 +1,15 @@
+package asist.io.dto.asistenciaDTO;
+
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+public class AsistenciaCreateDTO {
+    private static final long serialVersionUID = 1L;
+
+    private String codigoAsistencia;
+    private String lu;
+    private String horarioId;
+}

--- a/src/main/java/asist/io/dto/asistenciaDTO/AsistenciaPostDTO.java
+++ b/src/main/java/asist/io/dto/asistenciaDTO/AsistenciaPostDTO.java
@@ -1,6 +1,7 @@
 package asist.io.dto.asistenciaDTO;
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -23,5 +24,6 @@ public class AsistenciaPostDTO implements Serializable {
     @NotEmpty(message = "La libreta universitaria no puede estar vacia")
     private String lu;
 
-    private String horarioId; 
+    @NotNull(message = "El horario no puede ser nulo")
+    private LocalDateTime horario;
 }

--- a/src/main/java/asist/io/service/IHorarioService.java
+++ b/src/main/java/asist/io/service/IHorarioService.java
@@ -1,6 +1,8 @@
 package asist.io.service;
 
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 
@@ -81,4 +83,13 @@ public interface IHorarioService {
      * @return Lista de encabezados
      */
     public Map<String, Horario> obtenerEncabezadosYHorariosEntreDosFechas(LocalDateTime fechaInicio, LocalDateTime fechaFin, String cursoId);
+
+    /**
+     * Obtiene un horario según los parámetros
+     * @param codigoAsistencia codigo del curso
+     * @param dia dia de la semana
+     * @param hora hora a verificar
+     * @return true si el horario es valido, false de lo contrario
+     */
+    public HorarioGetDTO obtenerHorario(String codigoAsistencia, DayOfWeek dia, LocalTime hora);
 } 

--- a/src/main/java/asist/io/service/impl/AsistenciaServiceImpl.java
+++ b/src/main/java/asist/io/service/impl/AsistenciaServiceImpl.java
@@ -1,13 +1,17 @@
 package asist.io.service.impl;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import asist.io.dto.HorarioDTO.HorarioGetDTO;
+import asist.io.dto.asistenciaDTO.AsistenciaCreateDTO;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
@@ -50,16 +54,23 @@ public class AsistenciaServiceImpl implements IAsistenciaService {
     @SuppressWarnings("null")
     @Override
     public AsistenciaGetDTO registrarAsistencia(AsistenciaPostDTO asistenciaPostDTO) {
+        DayOfWeek dia = asistenciaPostDTO.getHorario().getDayOfWeek();
+        LocalTime hora = asistenciaPostDTO.getHorario().toLocalTime();
+        HorarioGetDTO horarioEncontrado =  horarioService.obtenerHorario(asistenciaPostDTO.getCodigoAsistencia(), dia, hora);
 
-        asistenciaPostDTO.setHorarioId(horarioService.obtenerHorarioPorLocalDateTime(asistenciaPostDTO.getCodigoAsistencia(),LocalDateTime.now()).getId());
+        AsistenciaCreateDTO asistenciaCreateDto = new AsistenciaCreateDTO();
+        asistenciaCreateDto.setCodigoAsistencia(asistenciaPostDTO.getCodigoAsistencia());
+        asistenciaCreateDto.setLu(asistenciaPostDTO.getLu());
+        asistenciaCreateDto.setHorarioId(horarioEncontrado.getHorarioId());
+
         validarAsistencia(asistenciaPostDTO);
-        
+
         logger.info("Registrando asistencia para el alumno, " + asistenciaPostDTO.getLu() + " en el curso " + asistenciaPostDTO.getCodigoAsistencia());
 
         return AsistenciaMapper.toDTO(asistenciaRepository.save(
             AsistenciaMapper.toEntity(asistenciaPostDTO,
             cursoService.obtenerCursoEntityPorCodigoAsistencia(asistenciaPostDTO.getCodigoAsistencia()),
-            estudianteService.obtenerEstudianteEntityPorCodigoAsistenciaYLu(asistenciaPostDTO.getCodigoAsistencia(),asistenciaPostDTO.getLu()),horarioService.obtenerHorarioEntityPorId(asistenciaPostDTO.getHorarioId()))));
+            estudianteService.obtenerEstudianteEntityPorCodigoAsistenciaYLu(asistenciaPostDTO.getCodigoAsistencia(),asistenciaPostDTO.getLu()),horarioService.obtenerHorarioEntityPorId(asistenciaCreateDto.getHorarioId()))));
     }
 
 
@@ -178,17 +189,17 @@ public class AsistenciaServiceImpl implements IAsistenciaService {
      * @throws ModelException Si la asistencia es nula, si el curso o el alumno no existen, o si el alumno ya tiene registrada una asistencia para la fecha
      */
     private void validarAsistencia(AsistenciaPostDTO asistenciaPostDTO){
-        if (asistenciaPostDTO == null) throw new ModelException("La asistencia no puede ser nula");
-        cursoService.obtenerCursoPorCodigoAsistencia(asistenciaPostDTO.getCodigoAsistencia());
-        estudianteService.obtenerEstudianteEntityPorCodigoAsistenciaYLu(asistenciaPostDTO.getCodigoAsistencia(), asistenciaPostDTO.getLu());
-        
-        try{
-            obtenerAsistenciaPorFechaLuYHorario(DateFormatter.localDateToString(LocalDate.now()),asistenciaPostDTO.getLu(), asistenciaPostDTO.getHorarioId());
-            logger.error("El alumno con LU " + asistenciaPostDTO.getLu() + " ya tiene registrada una asistencia para la fecha " + DateFormatter.localDateTimeToString(LocalDateTime.now()));
-            throw new ModelException("El alumno con LU " + asistenciaPostDTO.getLu() + " ya tiene registrada una asistencia para la fecha " + DateFormatter.localDateTimeToString(LocalDateTime.now()));
-        }catch(ModelException e){
-            logger.info ("Asistencia validada con exito");
-        }
+//        if (asistenciaPostDTO == null) throw new ModelException("La asistencia no puede ser nula");
+//        cursoService.obtenerCursoPorCodigoAsistencia(asistenciaPostDTO.getCodigoAsistencia());
+//        estudianteService.obtenerEstudianteEntityPorCodigoAsistenciaYLu(asistenciaPostDTO.getCodigoAsistencia(), asistenciaPostDTO.getLu());
+//
+//        try{
+//            obtenerAsistenciaPorFechaLuYHorario(DateFormatter.localDateToString(LocalDate.now()),asistenciaPostDTO.getLu(), asistenciaPostDTO.getHorarioId());
+//            logger.error("El alumno con LU " + asistenciaPostDTO.getLu() + " ya tiene registrada una asistencia para la fecha " + DateFormatter.localDateTimeToString(LocalDateTime.now()));
+//            throw new ModelException("El alumno con LU " + asistenciaPostDTO.getLu() + " ya tiene registrada una asistencia para la fecha " + DateFormatter.localDateTimeToString(LocalDateTime.now()));
+//        }catch(ModelException e){
+//            logger.info ("Asistencia validada con exito");
+//        }
     }
     
 

--- a/src/main/java/asist/io/service/impl/HorarioServiceImpl.java
+++ b/src/main/java/asist/io/service/impl/HorarioServiceImpl.java
@@ -1,6 +1,8 @@
 package asist.io.service.impl;
 
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.List;
@@ -177,6 +179,26 @@ public class HorarioServiceImpl implements IHorarioService {
             }
         }
         return horarioPorEncabezado;
+    }
+
+    @Override
+    /**
+     * Obtiene un horario según los parámetros
+     * @param codigoAsistencia codigo del curso
+     * @param dia dia de la semana
+     * @param hora hora a verificar
+     * @return true si el horario es valido, false de lo contrario
+     */
+    public HorarioGetDTO obtenerHorario(String codigoAsistencia, DayOfWeek dia, LocalTime hora) {
+        Horario horario = horarioRepository.findHorarioContainingTime(codigoAsistencia, dia, hora);
+
+        if(horario == null){
+            logger.error("No se encontro un horario para el dia " + dia + " y la hora " + hora);
+            throw new ModelException("No se encontro un horario para el dia " + dia + " y la hora " + hora);
+        }
+
+        logger.info("Horario encontrado para el dia " + dia + " y la hora " + hora + " con exito");
+        return HorarioMapper.toDTO(horario);
     }
 
     /**

--- a/src/test/java/asist/io/AsistenciaTest.java
+++ b/src/test/java/asist/io/AsistenciaTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -133,6 +134,7 @@ public class AsistenciaTest {
         asistenciaPostDTO = new AsistenciaPostDTO();
         asistenciaPostDTO.setCodigoAsistencia("151511155");
         asistenciaPostDTO.setLu("123122312312312");
+        asistenciaPostDTO.setHorario(LocalDateTime.now());
 
         // Se comprueba que no se permite registrar una asistencia si el curso no existe
         assertThrows( ModelException.class, () -> target.registrarAsistencia(asistenciaPostDTO));
@@ -147,6 +149,7 @@ public class AsistenciaTest {
     @Test
     @DisplayName("Test de obtener asistencia por curso")
     public void obtenerAsistenciaPorCursoTest(){
+        asistenciaPostDTO.setHorario(LocalDateTime.now());
         target.registrarAsistencia(asistenciaPostDTO);
         asistenciaPostDTO.setLu(estudiante2.getLu());
         target.registrarAsistencia(asistenciaPostDTO);
@@ -164,6 +167,7 @@ public class AsistenciaTest {
     @Test
     @DisplayName("Test de obtener asistencia por estudiante")
     public void obtenerAsistenciaPorEstudianteTest(){
+        asistenciaPostDTO.setHorario(LocalDateTime.now());
         target.registrarAsistencia(asistenciaPostDTO);
         asistenciaPostDTO.setLu(estudiante2.getLu());
         target.registrarAsistencia(asistenciaPostDTO);


### PR DESCRIPTION
El DTO para crear una asistencia contenía el campo `horarioId` de tipo String lo cúal puede ser incorrecto (ya que en un inicio el usuario no debería de saber el id del horario). 

Se lo cambió a un tipo de dato LocalDateTime para que compruebe en la BD si hay coincidencia con algún horario disponible.

## Ejemplo

### Antes

```
POST /api/v1/asistencias/registrar

{
    "lu": "APU001",
    "codigoAsistencia": "aea910",
    "horarioId": "56543ded-4a08-11ef-b2b4-0242ac14000"
}
```

> [!CAUTION]
> Pasar por horario como un id es incorrecto. 
>
> En la parte del front-end se tendría que recuperar todos los datos del curso, seguido de los datos de los horarios disponibles y verificar cual de esos es el correspondiente. Esto resulta costoso y muy rebuscado para desarrollarlo.

---

### Ahora

```
POST /api/v1/asistencias/registrar

{
    "lu": "APU001",
    "codigoAsistencia": "aea910",
    "horario": "2024-07-24T21:15:30"
}
```

> [!TIP]
> Pasar el horario como un `LocalDateTime` resulta mas conveniente para el front-end.
>
> Aqui pasamos la fecha como un `LocalDateTime` con la cual podremos realizar una query en la base de datos para determinar si hay alguna coincidencia. Esto resulta mas sencillo y fácil de usar.

## Tests

Los tests han sido reajustados al cambio realizado y funcionan correctamente.

![image](https://github.com/user-attachments/assets/a91712e2-eca2-4a1e-add8-ea09aa58a5f8)
